### PR TITLE
Add Python version of chatter analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ To use this, just type in MATLAB
 
     run_MCA
 
+### Python Version
+
+You can also run an equivalent analysis with Python using `run_mca.py`:
+
+```bash
+python -m python.run_mca
+```
+
+
 Then you will get these results:
 
 ![](images/conv_SLD_MCA_aed_300_tool_1.png)

--- a/python/calc_f_g_h.py
+++ b/python/calc_f_g_h.py
@@ -1,0 +1,55 @@
+import numpy as np
+from scipy.linalg import expm
+
+
+def calc_fgh(sdm, tool, work, o, w):
+    k = sdm.k
+    wa = sdm.wa
+    wb = sdm.wb
+    flutes = tool['flutes']
+    Kf = work.Kf
+
+    tau = 2*np.pi/o/flutes
+    dt = tau/k
+
+    A = tool['plant']['A']
+    B = tool['plant']['B']
+    C = tool['plant']['C']
+
+    n = A.shape[0]
+
+    Dmat = np.zeros((n*(k+1), n*(k+1)))
+    Dmat[n: , n: ] = np.eye(n*k)
+
+    F = np.eye(n*(k+1))
+    G = np.zeros((n*(k+1), k))
+    E = np.zeros((n*(k+1), 1))
+    H = np.zeros((2, (k+1)*n))
+
+    for i in range(k):
+        Bc = w*(B@Kf[:,:,i])
+        Ac2 = Bc@C
+        Ac1 = A - Ac2
+        P = expm(Ac1*dt)
+        R = (P - np.eye(n)) @ np.linalg.inv(Ac1) @ Ac2
+        Q = (P - np.eye(n)) @ np.linalg.inv(Ac1) @ Bc
+        Dmat[0:n, 0:n] = P
+        Dmat[0:n, n*(k+1)-2*n:n*(k+1)-n] = wa*R
+        Dmat[0:n, n*(k+1)-n:n*(k+1)] = wb*R
+        E[0:n,0] = Q[:,0]
+
+        Fi0 = F.copy()
+        F[0:n,:] = P@Fi0[0:n,:] + Dmat[0:n, n*(k+1)-2*n:n*(k+1)] @ Fi0[n*(k+1)-2*n:n*(k+1),:]
+        F[n:n*(k+1),:] = Fi0[0:n*k,:]
+
+        G0 = G.copy()
+        G[:,i] = E[:,0]
+        G[0:n,0:i+1] = P@G[0:n,0:i+1] + Dmat[0:n, n*(k+1)-2*n:n*(k+1)] @ G0[n*(k+1)-2*n:n*(k+1), 0:i+1]
+        G[n:n*(k+1),0:i+1] = G0[0:n*k,0:i+1]
+
+        Dmat.fill(0)
+
+    for i in range(k+1):
+        H[0:2, n*i:n*(i+1)] = C
+
+    return F, G, H

--- a/python/calc_kf_cs.py
+++ b/python/calc_kf_cs.py
@@ -1,0 +1,29 @@
+import numpy as np
+from . import make_global as g
+
+
+def calc_kf(tool, sdm, work):
+    k = sdm.k
+    intk = sdm.intk
+    flutes = tool['flutes']
+    fist = tool['fist']
+    fiex = tool['fiex']
+    Kt = work.Kt
+    Kn = work.Kn
+
+    Kf_mat = np.zeros((2, 2, k))
+    phi = np.zeros(intk)
+
+    for i in range(k):
+        dtr = 2*np.pi/flutes/k
+        for j in range(flutes):
+            garr = np.zeros(intk)
+            for h in range(intk):
+                phi[h] = (dtr*(i + (h+1)/intk) + j*2*np.pi/flutes) % (2*np.pi)
+                if fist <= phi[h] <= fiex:
+                    garr[h] = 1
+            Kf_mat[0,0,i] += np.sum(garr*(Kt*np.cos(phi)+Kn*np.sin(phi))*np.sin(phi))/intk
+            Kf_mat[0,1,i] += np.sum(garr*(Kt*np.cos(phi)+Kn*np.sin(phi))*np.cos(phi))/intk
+            Kf_mat[1,0,i] += np.sum(garr*(-Kt*np.sin(phi)+Kn*np.cos(phi))*np.sin(phi))/intk
+            Kf_mat[1,1,i] += np.sum(garr*(-Kt*np.sin(phi)+Kn*np.cos(phi))*np.cos(phi))/intk
+    return Kf_mat

--- a/python/make_global.py
+++ b/python/make_global.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+# Global parameters equivalent to data/make_Global.m
+AE = 3/1000  # radial depth of cut (m)
+D = 10/1000  # diameter of tool (m)
+FLUTES = 4   # number of teeth
+UP_OR_DOWN = -1  # down milling (-1)
+W_ST = 0/1000  # starting depth of cut (m)
+W_FI = 10/1000  # final depth of cut (m)
+O_ST = (2*np.pi/60) * 4000  # starting spindle speed (rad/s)
+O_FI = (2*np.pi/60) * 8000  # final spindle speed (rad/s)
+TAU_NORM = 10e-3  # nominal period for SLD (s)
+
+# derived nominal speed (rpm)
+O_NORM = 60/TAU_NORM/FLUTES

--- a/python/make_sdm.py
+++ b/python/make_sdm.py
@@ -1,0 +1,11 @@
+import numpy as np
+from . import make_global as g
+
+# Semi-Discretization Method parameters equivalent to data/make_SDM.m
+class SDM:
+    stx = 50  # steps of spindle speed
+    sty = 50  # steps of depth of cut
+    k = round(2*np.pi/g.O_ST*8*1e3/g.FLUTES)  # tau = k dt
+    intk = 20  # tau_Kf = intk * dt
+    wa = 0.5
+    wb = 0.5

--- a/python/make_tool.py
+++ b/python/make_tool.py
@@ -1,0 +1,77 @@
+import numpy as np
+from scipy import signal
+from . import make_global as g
+
+
+def build_tool(tool_idx):
+    s = signal.lti([], [], [])  # placeholder for lti representation
+    if tool_idx == 1:
+        mass = 0.4
+        omegan = 1435*2*np.pi
+        zeta = 0.012
+        M = mass
+        K = M*omegan**2
+        B = 2*zeta/omegan*K
+        # second order system 1/(Ms^2 + Bs + K)
+        num = [1]
+        den = [M, B, K]
+    elif tool_idx == 2:
+        K0 = 1e8
+        omegani = [1925*2*np.pi, 1200*2*np.pi]
+        zetai = [0.01, 0.006]
+        num = [1/K0]
+        den = [1]
+        for on, z in zip(omegani, zetai):
+            num = np.polymul(num, [on**2])
+            den = np.polymul(den, [1, 2*z*on, on**2])
+    elif tool_idx == 3:
+        K = 0.25*1e9
+        on = np.array([1052, 1648])*2*np.pi
+        zeta = [0.005, 0.005]
+        num = [1/K]
+        den = [1]
+        for o_i, z in zip(on, zeta):
+            num = np.polymul(num, [o_i**2])
+            den = np.polymul(den, [1, 2*z*o_i, o_i**2])
+    elif tool_idx == 4:
+        K = 0.58*1e9
+        on = 1190*2*np.pi
+        zeta = 0.0019
+        num = [1/K]
+        den = [1, 2*zeta*on, on**2]
+    elif tool_idx == 5:
+        K = 0.25*1e9
+        on = np.array([1470, 1510, 1650, 1900, 2100])*2*np.pi
+        zeta = [0.005]*5
+        num = [1/K]
+        den = [1]
+        for o_i, z in zip(on, zeta):
+            num = np.polymul(num, [o_i**2])
+            den = np.polymul(den, [1, 2*z*o_i, o_i**2])
+    else:
+        raise ValueError("Unsupported tool")
+
+    # convert to state-space, replicate for 2 DOF
+    sys = signal.StateSpace(*signal.tf2ss(num, den))
+    A, B, C, D = sys.A, sys.B, sys.C, sys.D
+    # 2x2 plant with identical dynamics
+    A = np.kron(np.eye(2), A)
+    B = np.kron(np.eye(2), B)
+    C = np.kron(np.eye(2), C)
+    D = np.kron(np.eye(2), D)
+    return {
+        'plant': {'A': A, 'B': B, 'C': C, 'D': D},
+        'flutes': g.FLUTES,
+        'fist': angle_in_out(g.UP_OR_DOWN, g.AE/g.D)[0],
+        'fiex': angle_in_out(g.UP_OR_DOWN, g.AE/g.D)[1]
+    }
+
+
+def angle_in_out(up_or_down, aD):
+    if up_or_down == 1:
+        fist = 0
+        fiex = np.arccos(1 - 2*aD)
+    else:
+        fist = np.arccos(2*aD - 1)
+        fiex = np.pi
+    return fist, fiex

--- a/python/make_work.py
+++ b/python/make_work.py
@@ -1,0 +1,5 @@
+# Cutting force coefficients equivalent to data/make_Work.m
+
+class Work:
+    Kt = 180e6*9.8  # tangential cutting force coefficient
+    Kn = 0.3*Kt     # normal cutting force coefficient

--- a/python/multirate_analysis_cs.py
+++ b/python/multirate_analysis_cs.py
@@ -1,0 +1,34 @@
+import numpy as np
+from scipy.linalg import eigvals, norm
+from . import make_global as g
+from .make_sdm import SDM
+from .make_work import Work
+from .make_tool import build_tool
+from .calc_kf_cs import calc_kf
+from .calc_f_g_h import calc_fgh
+
+
+def multirate_analysis(tool_idx):
+    tool = build_tool(tool_idx)
+    sdm = SDM()
+    work = Work()
+    work.Kf = calc_kf(tool, sdm, work)
+
+    sdm.sso = np.zeros((sdm.stx+1, sdm.sty+1))
+    sdm.dc = np.zeros_like(sdm.sso)
+    sdm.ei = np.zeros_like(sdm.sso)
+    sdm.forcedHinf = np.zeros_like(sdm.sso)
+
+    for ix in range(sdm.stx + 1):
+        o = g.O_ST + ix*(g.O_FI - g.O_ST)/sdm.stx
+        tool = build_tool(tool_idx)  # update due to o? same as MATLAB call
+        for iy in range(sdm.sty + 1):
+            w = g.W_ST + iy*(g.W_FI - g.W_ST)/sdm.sty
+            F, G, H = calc_fgh(sdm, tool, work, o, w)
+            sdm.sso[ix, iy] = o
+            sdm.dc[ix, iy] = w
+            eig_max = max(abs(eigvals(F)))
+            sdm.ei[ix, iy] = eig_max**(o/g.O_NORM)
+            inv_if = np.linalg.inv(np.eye(F.shape[0]) - F)
+            sdm.forcedHinf[ix, iy] = norm(H @ inv_if @ G)
+    return sdm

--- a/python/run_mca.py
+++ b/python/run_mca.py
@@ -1,0 +1,16 @@
+import datetime
+import os
+from .multirate_analysis_cs import multirate_analysis
+from .save_all import save_results
+
+
+def run():
+    supertime = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+    dirname = os.path.join('result', f'SLD_MCA_{supertime}')
+    tool_list = [1, 2]
+    for tool in tool_list:
+        sdm = multirate_analysis(tool)
+        save_results(dirname, tool, sdm)
+
+if __name__ == '__main__':
+    run()

--- a/python/save_all.py
+++ b/python/save_all.py
@@ -1,0 +1,46 @@
+import os
+import numpy as np
+from scipy.io import savemat
+import matplotlib.pyplot as plt
+
+from . import make_global as g
+
+
+def save_results(dirname, tool_idx, sdm):
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+    filename = f"MCA_aed_{round(g.AE/g.D*1000)}_tool_{tool_idx}"
+    savemat(os.path.join(dirname, f"{filename}.mat"), {
+        'sso': sdm.sso,
+        'dc': sdm.dc,
+        'ei': sdm.ei,
+        'forcedHinf': sdm.forcedHinf
+    })
+
+    X = sdm.sso*60/2/np.pi
+    Y = sdm.dc*1000
+
+    fig, ax = plt.subplots()
+    cs = ax.contour(X, Y, 20*np.log10(sdm.ei), levels=[0])
+    ax.clabel(cs, inline=True)
+    ax.set_xlabel('Spindle speed (rpm)')
+    ax.set_ylabel('Axial depth of cut (mm)')
+    fig.savefig(os.path.join(dirname, f'SLD_{filename}.png'))
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    cs = ax.contourf(X, Y, 20*np.log10(sdm.ei))
+    fig.colorbar(cs)
+    ax.contour(X, Y, 20*np.log10(sdm.ei), levels=[0], colors='r')
+    ax.set_xlabel('Spindle speed (rpm)')
+    ax.set_ylabel('Axial depth of cut (mm)')
+    fig.savefig(os.path.join(dirname, f'conv_SLD_{filename}.png'))
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    cs = ax.contourf(X, Y, 20*np.log10(sdm.forcedHinf))
+    fig.colorbar(cs)
+    ax.set_xlabel('Spindle speed (rpm)')
+    ax.set_ylabel('Axial depth of cut (mm)')
+    fig.savefig(os.path.join(dirname, f'Forced_{filename}.png'))
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- add a Python implementation replicating MATLAB analysis
- document how to run the Python script

## Testing
- `python -m python.run_mca` *(fails: numpy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687850e016488323b93f7f28daf5e111